### PR TITLE
Fix grammar issue in "an alias"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ import "io"
 type T int
 type t int
 
-type A = T         // want "A is a alias for T but it is exported type"
+type A = T         // want "A is an alias for T but it is exported type"
 type B = t         // OK
 type C = io.Writer // OK
 

--- a/innertypealias.go
+++ b/innertypealias.go
@@ -76,7 +76,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				pass.Report(analysis.Diagnostic{
 					Pos:            spec.Pos(),
 					End:            spec.End(),
-					Message:        fmt.Sprintf("%s is a alias for %s but it is exported type", x, y),
+					Message:        fmt.Sprintf("%s is an alias for %s but it is exported type", x, y),
 					SuggestedFixes: []analysis.SuggestedFix{fix},
 				})
 			}

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -5,7 +5,7 @@ import "io"
 type T int
 type t int
 
-type A = T         // want "A is a alias for T but it is exported type"
+type A = T         // want "A is an alias for T but it is exported type"
 type B = t         // OK
 type C = io.Writer // OK
 


### PR DESCRIPTION
This PR fixes linter's output: `a alias` -> `an alias`.